### PR TITLE
added App() and getRunTimeType()

### DIFF
--- a/places/android/gradle.properties
+++ b/places/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=true

--- a/places/lib/main.dart
+++ b/places/lib/main.dart
@@ -3,7 +3,7 @@ import 'dart:ffi';
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
 }
 
 class MyApp extends StatelessWidget {
@@ -15,10 +15,19 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: MySecondWidget(), //MyHomePage(title: 'Flutter Demo Home Page'),
+      home:MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
 }
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return  MaterialApp(
+      home: MySecondWidget(),
+    );
+  }
+}
+
 
 class MyHomePage extends StatefulWidget {
   MyHomePage({Key key, this.title}) : super(key: key);
@@ -88,6 +97,7 @@ class MyFirstWidget extends StatelessWidget {
       ),
     );
   }
+
 }
 
 class MySecondWidget extends StatefulWidget {
@@ -112,8 +122,10 @@ class _MySecondWidgetState extends State<MySecondWidget> {
     print("counter: $_counter");
     return Container(
       child: Center(
-        child: Text('Hello!'),
+        child: Text('Hello! $getRunTimeType'),
       ),
     );
   }
+
+  Type getRunTimeType() => context.runtimeType;
 }


### PR DESCRIPTION
1)после переименования все отлично запустилось. 
неважно как назвать, главное чтобы переименование по всему проекту было, плюс внутри есть метод main, который важен для запуска проекта как точка входа. 

2)после зауска приложения с MyApp(), а потом переименовав на App(), в котором вызов виджета StatefulWidget с прошлого урока, почему то поверх запустился текст 
https://prnt.sc/z2jice

3)без аргументов не получится возвращать контекст 
Type getRunTimeType() => context.runtimeType;
The getter 'context' isn't defined for the class 'MyFirstWidget’.
нет доступа вне метода build

4)после перемещения - получилось. почему -  потому что в стейте есть геттер контекст.

Вопрос:
почему так случилось в пункте 2? почему поверх? 